### PR TITLE
Add info about serial-authority header in model.md

### DIFF
--- a/docs/en/reference/assertions/model.md
+++ b/docs/en/reference/assertions/model.md
@@ -15,9 +15,10 @@ authority-id:      <authority account id>
 revision:          <int>
 series             <string>
 brand-id           <account id>
+serial-authority   <list<string>> # optional list of serial authorities. Use “generic” to have the snap store generate a serial.
 model              <model id>
-classic            <true|false>
-store              <string>
+classic            <true|false> # optional
+store              <string> # optional
 display-name       <descriptive string>
 architecture       <debian architecture name>
 gadget             <gadget snap name>
@@ -34,6 +35,10 @@ allows the brand to define which release of the platform the device uses.
 “rolling” is the name of the development series that bridges stable series,
 which have names like “16” or “18”. `brand-id` is the account id of the brand, and `model`
 is a string that identifies a set of devices as desired by the brand.
+
+The (optional) `serial-authority` header allows to specify the authority id for the serial assertion.
+In most cases, this is not necessary. It's also possible to specify `generic`, in which case snapd 
+will issue a generic serial from the main Ubuntu snap store.
 
 The (optional) `classic` flag tells us if this is an all-snap system (false) or not (true).
 If not set, `architecture`, `gadget`, and `kernel` are mandatory. If set, `kernel`


### PR DESCRIPTION
As pointed out by @ogra1 on [IRC](https://irclogs.ubuntu.com/2020/11/11/%23snappy.txt) (at 12:47), this header allows custom gadget images to receive a generic serial from the Ubuntu snap store. This will 
1. prevent misleading errors for `initialize device` in `snap changes` if the gadget's `register-device` hook does nothing
2. allow for proper statistics in the snap store dashboard, as the Weekly Active Devices are counted based on their serial.

This is helpful for pre-production tinkering or open source projects that distribute custom images without a custom serial vault.